### PR TITLE
docs: plugin ids variable expansion cannot use secret store

### DIFF
--- a/docs/include/filter.asciidoc
+++ b/docs/include/filter.asciidoc
@@ -146,6 +146,8 @@ Adding a named ID in this case will help in monitoring Logstash when using the m
       }
     }
 
+NOTE: Variable substitution in the `id` field only supports environment variables
+      and does not support the use of values from the secret store.
 
 ifeval::["{versioned_docs}"!="true"]
 [id="plugins-{type}s-{plugin}-periodic_flush"]

--- a/docs/include/input.asciidoc
+++ b/docs/include/input.asciidoc
@@ -112,6 +112,8 @@ input {
 }
 ---------------------------------------------------------------------------------------------------
 
+NOTE: Variable substitution in the `id` field only supports environment variables
+      and does not support the use of values from the secret store.
 
 ifeval::["{versioned_docs}"!="true"]
 [id="plugins-{type}s-{plugin}-tags"]

--- a/docs/include/output.asciidoc
+++ b/docs/include/output.asciidoc
@@ -89,4 +89,6 @@ output {
 }
 ---------------------------------------------------------------------------------------------------
 
+NOTE: Variable substitution in the `id` field only supports environment variables
+      and does not support the use of values from the secret store.
 


### PR DESCRIPTION
This is a proposed amendment to elastic/logstash#11592, which adds a note about variable expansion in the `id` field to the documentation of all inputs, outputs, and filters.

Although codecs have an `id` option by nature of inheriting `LogStash::Plugin`, it is not common practice to give ids to codecs and the option is not documented at all in the codec-common include, so I have not added it here.