### PR TITLE
Switched capture strategy directly adding spy appender

### DIFF
--- a/logstash-core/spec/logstash/settings/setting_with_deprecated_alias_spec.rb
+++ b/logstash-core/spec/logstash/settings/setting_with_deprecated_alias_spec.rb
@@ -39,34 +39,27 @@ describe LogStash::Setting::SettingWithDeprecatedAlias do
 
     # override the append to catch all the calls and collect the events
     def append(log_event)
-      puts "DNADBG>> CustomAppender.append invoked log_event: #{log_event}"
-      @events_collector << "#{log_event.message.formatted_message}"
-      puts "DNADBG>> CustomAppender.append invoked list content: #{events_collector}"
+      @events_collector << log_event.message.formatted_message
     end
   end
 
   let(:events) { [] }
 
   before(:each) do
-    # Initialization of appender and logger use to spy, need to be freshly recreated on each test is context shutdown is used.
     java_import org.apache.logging.log4j.LogManager
     logger = LogManager.getLogger("org.logstash.settings.DeprecatedAlias")
+    deprecated_logger = LogManager.getLogger("org.logstash.deprecation.settings.DeprecatedAlias")
+
+    @custom_appender = CustomAppender.new(events).tap {|appender| appender.start }
+
     java_import org.apache.logging.log4j.Level
+    logger.addAppender(@custom_appender)
+    deprecated_logger.addAppender(@custom_appender)
+    # had to set level after appending as it was "error" for some reason
     logger.setLevel(Level::INFO)
-    expect(logger.info_enabled?).to be_truthy
-    custom_appender = CustomAppender.new([])
-    custom_appender.start
-    logger.addAppender(custom_appender)
-    #Verify the appender receives the log line from Logger
-    custom_appender.events_collector << "12345"
-    puts "DNADBG>> before - before calling log.info, events: #{custom_appender.events_collector}"
-    logger.info("Test ping message")
-    puts "DNADBG>> before - just after called log.info, events: #{custom_appender.events_collector}"
+    deprecated_logger.setLevel(Level::INFO)
 
-    expect(custom_appender.events_collector).not_to be_empty
-
-    # expect(events[0].message.formatted_message).to include("Test ping message")
-    events.clear
+    expect(@custom_appender.started?).to be_truthy
 
     allow(LogStash::Settings).to receive(:logger).and_return(double("SettingsLogger").as_null_object)
     allow(LogStash::Settings).to receive(:deprecation_logger).and_return(double("SettingsDeprecationLogger").as_null_object)
@@ -76,127 +69,134 @@ describe LogStash::Setting::SettingWithDeprecatedAlias do
 
   after(:each) do
     events.clear
+    java_import org.apache.logging.log4j.LogManager
+    logger = LogManager.getLogger("org.logstash.settings.DeprecatedAlias")
+    deprecated_logger = LogManager.getLogger("org.logstash.deprecation.settings.DeprecatedAlias")
+    # The Logger's AbstractConfiguration contains a cache of Appender, by class name. The cache is updated
+    # iff is absent, so to make subsequent add_appender effective we have cleanup on teardown, else the new
+    # appender instance is simply not used by the logger
+    logger.remove_appender(@custom_appender)
+    deprecated_logger.remove_appender(@custom_appender)
   end
 
-  # shared_examples '#validate_value success' do
-  #   context '#validate_value' do
-  #     it "returns without raising" do
-  #       expect { settings.get_setting(canonical_setting_name).validate_value }.to_not raise_error
-  #     end
-  #   end
-  # end
-  #
-  # xcontext "when neither canonical setting nor deprecated alias are set" do
-  #   it 'resolves to the default' do
-  #     expect(settings.get(canonical_setting_name)).to eq(default_value)
-  #   end
-  #
-  #   it 'does not produce a relevant deprecation warning' do
-  #     expect(LogStash::Settings.deprecation_logger).to_not have_received(:deprecated).with(a_string_including(deprecated_setting_name))
-  #   end
-  #
-  #   include_examples '#validate_value success'
-  #
-  #   context "#observe_post_process" do
-  #     it 'does not emit a deprecation warning' do
-  #       expect(LogStash::Settings.deprecation_logger).to_not receive(:deprecated).with(a_string_including(deprecated_setting_name))
-  #       settings.get_setting(deprecated_setting_name).observe_post_process
-  #       expect(events).to be_empty
-  #     end
-  #   end
-  # end
+  shared_examples '#validate_value success' do
+    context '#validate_value' do
+      it "returns without raising" do
+        expect { settings.get_setting(canonical_setting_name).validate_value }.to_not raise_error
+      end
+    end
+  end
 
-  # xcontext "when only the deprecated alias is set" do
-  #   let(:value) { "crusty_value" }
-  #
-  #   before(:each) do
-  #     settings.set(deprecated_setting_name, value)
-  #     settings.get_setting(deprecated_setting_name).observe_post_process
-  #   end
-  #
-  #   it 'resolves to the value provided for the deprecated alias' do
-  #     expect(settings.get(canonical_setting_name)).to eq(value)
-  #   end
-  #
-  #   it 'logs a deprecation warning' do
-  #     expect(events[0].message.formatted_message).to include(deprecated_setting_name)
-  #   end
-  #
-  #   include_examples '#validate_value success'
-  #
-  #   context "#observe_post_process" do
-  #     it 're-emits the deprecation warning' do
-  #       settings.get_setting(deprecated_setting_name).observe_post_process
-  #       expect(events[0].message.formatted_message).to include(deprecated_setting_name)
-  #     end
-  #   end
-  #
-  #   it 'validates deprecated alias' do
-  #     expect { settings.get_setting(canonical_setting_name).deprecated_alias.validate_value }.to_not raise_error
-  #   end
-  #
-  #   context 'using a boolean setting' do
-  #     let(:value) { true }
-  #     let(:default_value) { false }
-  #
-  #     let(:canonical_setting) { LogStash::Setting::Boolean.new(canonical_setting_name, default_value, true) }
-  #
-  #     it 'resolves to the value provided for the deprecated alias' do
-  #       expect(settings.get(canonical_setting_name)).to eq(true)
-  #     end
-  #
-  #     include_examples '#validate_value success'
-  #
-  #     it 'validates deprecated alias' do
-  #       expect { settings.get_setting(canonical_setting_name).deprecated_alias.validate_value }.to_not raise_error
-  #     end
-  #   end
-  # end
+  context "when neither canonical setting nor deprecated alias are set" do
+    it 'resolves to the default' do
+      expect(settings.get(canonical_setting_name)).to eq(default_value)
+    end
 
-  # xcontext "when only the canonical setting is set" do
-  #   before(:each) do
-  #     settings.set(canonical_setting_name, "shiny_value")
-  #   end
-  #
-  #   it "resolves to the value provided for the canonical setting" do
-  #     expect(settings.get(canonical_setting_name)).to eq("shiny_value")
-  #   end
-  #
-  #   it 'does not produce a relevant deprecation warning' do
-  #     settings.get_setting(deprecated_setting_name).observe_post_process
-  #     expect(events).to be_empty
-  #   end
-  #
-  #   include_examples '#validate_value success'
-  #
-  #   context "#observe_post_process" do
-  #     it 'does not emit a deprecation warning' do
-  #       settings.get_setting(deprecated_setting_name).observe_post_process
-  #       expect(events).to be_empty
-  #     end
-  #   end
-  # end
+    it 'does not produce a relevant deprecation warning' do
+      expect(LogStash::Settings.deprecation_logger).to_not have_received(:deprecated).with(a_string_including(deprecated_setting_name))
+    end
 
-  # xcontext "when both the canonical setting and deprecated alias are set" do
-  #   before(:each) do
-  #     settings.set(deprecated_setting_name, "crusty_value")
-  #     settings.set(canonical_setting_name, "shiny_value")
-  #   end
-  #
-  #   context '#validate_value' do
-  #     it "raises helpful exception" do
-  #       expect { settings.get_setting(canonical_setting_name).validate_value }
-  #         .to raise_exception(java.lang.IllegalStateException, a_string_including("Both `#{canonical_setting_name}` and its deprecated alias `#{deprecated_setting_name}` have been set. Please only set `#{canonical_setting_name}`"))
-  #     end
-  #   end
-  # end
+    include_examples '#validate_value success'
+
+    context "#observe_post_process" do
+      it 'does not emit a deprecation warning' do
+        expect(LogStash::Settings.deprecation_logger).to_not receive(:deprecated).with(a_string_including(deprecated_setting_name))
+        settings.get_setting(deprecated_setting_name).observe_post_process
+        expect(events).to be_empty
+      end
+    end
+  end
+
+  context "when only the deprecated alias is set" do
+    let(:value) { "crusty_value" }
+
+    before(:each) do
+      settings.set(deprecated_setting_name, value)
+      settings.get_setting(deprecated_setting_name).observe_post_process
+    end
+
+    it 'resolves to the value provided for the deprecated alias' do
+      expect(settings.get(canonical_setting_name)).to eq(value)
+    end
+
+    it 'logs a deprecation warning' do
+      expect(events[0]).to include(deprecated_setting_name)
+    end
+
+    include_examples '#validate_value success'
+
+    context "#observe_post_process" do
+      it 're-emits the deprecation warning' do
+        settings.get_setting(deprecated_setting_name).observe_post_process
+        expect(events[0]).to include(deprecated_setting_name)
+      end
+    end
+
+    it 'validates deprecated alias' do
+      expect { settings.get_setting(canonical_setting_name).deprecated_alias.validate_value }.to_not raise_error
+    end
+
+    context 'using a boolean setting' do
+      let(:value) { true }
+      let(:default_value) { false }
+
+      let(:canonical_setting) { LogStash::Setting::Boolean.new(canonical_setting_name, default_value, true) }
+
+      it 'resolves to the value provided for the deprecated alias' do
+        expect(settings.get(canonical_setting_name)).to eq(true)
+      end
+
+      include_examples '#validate_value success'
+
+      it 'validates deprecated alias' do
+        expect { settings.get_setting(canonical_setting_name).deprecated_alias.validate_value }.to_not raise_error
+      end
+    end
+  end
+
+  context "when only the canonical setting is set" do
+    before(:each) do
+      settings.set(canonical_setting_name, "shiny_value")
+    end
+
+    it "resolves to the value provided for the canonical setting" do
+      expect(settings.get(canonical_setting_name)).to eq("shiny_value")
+    end
+
+    it 'does not produce a relevant deprecation warning' do
+      settings.get_setting(deprecated_setting_name).observe_post_process
+      expect(events).to be_empty
+    end
+
+    include_examples '#validate_value success'
+
+    context "#observe_post_process" do
+      it 'does not emit a deprecation warning' do
+        settings.get_setting(deprecated_setting_name).observe_post_process
+        expect(events).to be_empty
+      end
+    end
+  end
+
+  context "when both the canonical setting and deprecated alias are set" do
+    before(:each) do
+      settings.set(deprecated_setting_name, "crusty_value")
+      settings.set(canonical_setting_name, "shiny_value")
+    end
+
+    context '#validate_value' do
+      it "raises helpful exception" do
+        expect { settings.get_setting(canonical_setting_name).validate_value }
+          .to raise_exception(java.lang.IllegalStateException, a_string_including("Both `#{canonical_setting_name}` and its deprecated alias `#{deprecated_setting_name}` have been set. Please only set `#{canonical_setting_name}`"))
+      end
+    end
+  end
 
   context 'Settings#get on deprecated alias' do
     it 'produces a WARN-level message to the logger' do
-      puts "DNADBG>> inside the test"
       settings.get(deprecated_setting_name)
-      puts "DNADBG>> inside the test - after exercise"
-      expect(events[0].message.formatted_message).to include("setting `#{canonical_setting_name}` has been queried by its deprecated alias `#{deprecated_setting_name}`")
+      sleep 0.1
+      expect(events[0]).to include("setting `#{canonical_setting_name}` has been queried by its deprecated alias `#{deprecated_setting_name}`")
     end
   end
 end

--- a/logstash-core/spec/logstash/settings/setting_with_deprecated_alias_spec.rb
+++ b/logstash-core/spec/logstash/settings/setting_with_deprecated_alias_spec.rb
@@ -33,13 +33,15 @@ describe LogStash::Setting::SettingWithDeprecatedAlias do
     attr_reader :events_collector
 
     def initialize(events)
-      super("CustomCaptorAppender", nil, nil, true, [])
+      super("CustomCaptorAppender", nil, nil, true, org.apache.logging.log4j.core.config.Property::EMPTY_ARRAY)
       @events_collector = events
     end
 
     # override the append to catch all the calls and collect the events
     def append(log_event)
-      events_collector << log_event
+      puts "DNADBG>> CustomAppender.append invoked log_event: #{log_event}"
+      @events_collector << "#{log_event.message.formatted_message}"
+      puts "DNADBG>> CustomAppender.append invoked list content: #{events_collector}"
     end
   end
 
@@ -52,9 +54,19 @@ describe LogStash::Setting::SettingWithDeprecatedAlias do
     java_import org.apache.logging.log4j.Level
     logger.setLevel(Level::INFO)
     expect(logger.info_enabled?).to be_truthy
-    # custom_appender = ::CustomAppender.new(events)
-    custom_appender = ::CustomAppender.send(:initialize, events)
+    custom_appender = CustomAppender.new([])
+    custom_appender.start
     logger.addAppender(custom_appender)
+    #Verify the appender receives the log line from Logger
+    custom_appender.events_collector << "12345"
+    puts "DNADBG>> before - before calling log.info, events: #{custom_appender.events_collector}"
+    logger.info("Test ping message")
+    puts "DNADBG>> before - just after called log.info, events: #{custom_appender.events_collector}"
+
+    expect(custom_appender.events_collector).not_to be_empty
+
+    # expect(events[0].message.formatted_message).to include("Test ping message")
+    events.clear
 
     allow(LogStash::Settings).to receive(:logger).and_return(double("SettingsLogger").as_null_object)
     allow(LogStash::Settings).to receive(:deprecation_logger).and_return(double("SettingsDeprecationLogger").as_null_object)
@@ -62,122 +74,128 @@ describe LogStash::Setting::SettingWithDeprecatedAlias do
     settings.register(canonical_setting.with_deprecated_alias(deprecated_setting_name))
   end
 
-  shared_examples '#validate_value success' do
-    context '#validate_value' do
-      it "returns without raising" do
-        expect { settings.get_setting(canonical_setting_name).validate_value }.to_not raise_error
-      end
-    end
+  after(:each) do
+    events.clear
   end
 
-  context "when neither canonical setting nor deprecated alias are set" do
-    it 'resolves to the default' do
-      expect(settings.get(canonical_setting_name)).to eq(default_value)
-    end
+  # shared_examples '#validate_value success' do
+  #   context '#validate_value' do
+  #     it "returns without raising" do
+  #       expect { settings.get_setting(canonical_setting_name).validate_value }.to_not raise_error
+  #     end
+  #   end
+  # end
+  #
+  # xcontext "when neither canonical setting nor deprecated alias are set" do
+  #   it 'resolves to the default' do
+  #     expect(settings.get(canonical_setting_name)).to eq(default_value)
+  #   end
+  #
+  #   it 'does not produce a relevant deprecation warning' do
+  #     expect(LogStash::Settings.deprecation_logger).to_not have_received(:deprecated).with(a_string_including(deprecated_setting_name))
+  #   end
+  #
+  #   include_examples '#validate_value success'
+  #
+  #   context "#observe_post_process" do
+  #     it 'does not emit a deprecation warning' do
+  #       expect(LogStash::Settings.deprecation_logger).to_not receive(:deprecated).with(a_string_including(deprecated_setting_name))
+  #       settings.get_setting(deprecated_setting_name).observe_post_process
+  #       expect(events).to be_empty
+  #     end
+  #   end
+  # end
 
-    it 'does not produce a relevant deprecation warning' do
-      expect(LogStash::Settings.deprecation_logger).to_not have_received(:deprecated).with(a_string_including(deprecated_setting_name))
-    end
+  # xcontext "when only the deprecated alias is set" do
+  #   let(:value) { "crusty_value" }
+  #
+  #   before(:each) do
+  #     settings.set(deprecated_setting_name, value)
+  #     settings.get_setting(deprecated_setting_name).observe_post_process
+  #   end
+  #
+  #   it 'resolves to the value provided for the deprecated alias' do
+  #     expect(settings.get(canonical_setting_name)).to eq(value)
+  #   end
+  #
+  #   it 'logs a deprecation warning' do
+  #     expect(events[0].message.formatted_message).to include(deprecated_setting_name)
+  #   end
+  #
+  #   include_examples '#validate_value success'
+  #
+  #   context "#observe_post_process" do
+  #     it 're-emits the deprecation warning' do
+  #       settings.get_setting(deprecated_setting_name).observe_post_process
+  #       expect(events[0].message.formatted_message).to include(deprecated_setting_name)
+  #     end
+  #   end
+  #
+  #   it 'validates deprecated alias' do
+  #     expect { settings.get_setting(canonical_setting_name).deprecated_alias.validate_value }.to_not raise_error
+  #   end
+  #
+  #   context 'using a boolean setting' do
+  #     let(:value) { true }
+  #     let(:default_value) { false }
+  #
+  #     let(:canonical_setting) { LogStash::Setting::Boolean.new(canonical_setting_name, default_value, true) }
+  #
+  #     it 'resolves to the value provided for the deprecated alias' do
+  #       expect(settings.get(canonical_setting_name)).to eq(true)
+  #     end
+  #
+  #     include_examples '#validate_value success'
+  #
+  #     it 'validates deprecated alias' do
+  #       expect { settings.get_setting(canonical_setting_name).deprecated_alias.validate_value }.to_not raise_error
+  #     end
+  #   end
+  # end
 
-    include_examples '#validate_value success'
+  # xcontext "when only the canonical setting is set" do
+  #   before(:each) do
+  #     settings.set(canonical_setting_name, "shiny_value")
+  #   end
+  #
+  #   it "resolves to the value provided for the canonical setting" do
+  #     expect(settings.get(canonical_setting_name)).to eq("shiny_value")
+  #   end
+  #
+  #   it 'does not produce a relevant deprecation warning' do
+  #     settings.get_setting(deprecated_setting_name).observe_post_process
+  #     expect(events).to be_empty
+  #   end
+  #
+  #   include_examples '#validate_value success'
+  #
+  #   context "#observe_post_process" do
+  #     it 'does not emit a deprecation warning' do
+  #       settings.get_setting(deprecated_setting_name).observe_post_process
+  #       expect(events).to be_empty
+  #     end
+  #   end
+  # end
 
-    context "#observe_post_process" do
-      it 'does not emit a deprecation warning' do
-        expect(LogStash::Settings.deprecation_logger).to_not receive(:deprecated).with(a_string_including(deprecated_setting_name))
-        settings.get_setting(deprecated_setting_name).observe_post_process
-        expect(events).to be_empty
-      end
-    end
-  end
-
-  context "when only the deprecated alias is set" do
-    let(:value) { "crusty_value" }
-
-    before(:each) do
-      settings.set(deprecated_setting_name, value)
-      settings.get_setting(deprecated_setting_name).observe_post_process
-    end
-
-    it 'resolves to the value provided for the deprecated alias' do
-      expect(settings.get(canonical_setting_name)).to eq(value)
-    end
-
-    it 'logs a deprecation warning' do
-      expect(events[0].message.formatted_message).to include(deprecated_setting_name)
-    end
-
-    include_examples '#validate_value success'
-
-    context "#observe_post_process" do
-      it 're-emits the deprecation warning' do
-        settings.get_setting(deprecated_setting_name).observe_post_process
-        expect(events[0].message.formatted_message).to include(deprecated_setting_name)
-      end
-    end
-
-    it 'validates deprecated alias' do
-      expect { settings.get_setting(canonical_setting_name).deprecated_alias.validate_value }.to_not raise_error
-    end
-
-    context 'using a boolean setting' do
-      let(:value) { true }
-      let(:default_value) { false }
-
-      let(:canonical_setting) { LogStash::Setting::Boolean.new(canonical_setting_name, default_value, true) }
-
-      it 'resolves to the value provided for the deprecated alias' do
-        expect(settings.get(canonical_setting_name)).to eq(true)
-      end
-
-      include_examples '#validate_value success'
-
-      it 'validates deprecated alias' do
-        expect { settings.get_setting(canonical_setting_name).deprecated_alias.validate_value }.to_not raise_error
-      end
-    end
-  end
-
-  context "when only the canonical setting is set" do
-    before(:each) do
-      settings.set(canonical_setting_name, "shiny_value")
-    end
-
-    it "resolves to the value provided for the canonical setting" do
-      expect(settings.get(canonical_setting_name)).to eq("shiny_value")
-    end
-
-    it 'does not produce a relevant deprecation warning' do
-      settings.get_setting(deprecated_setting_name).observe_post_process
-      expect(events).to be_empty
-    end
-
-    include_examples '#validate_value success'
-
-    context "#observe_post_process" do
-      it 'does not emit a deprecation warning' do
-        settings.get_setting(deprecated_setting_name).observe_post_process
-        expect(events).to be_empty
-      end
-    end
-  end
-
-  context "when both the canonical setting and deprecated alias are set" do
-    before(:each) do
-      settings.set(deprecated_setting_name, "crusty_value")
-      settings.set(canonical_setting_name, "shiny_value")
-    end
-
-    context '#validate_value' do
-      it "raises helpful exception" do
-        expect { settings.get_setting(canonical_setting_name).validate_value }
-          .to raise_exception(java.lang.IllegalStateException, a_string_including("Both `#{canonical_setting_name}` and its deprecated alias `#{deprecated_setting_name}` have been set. Please only set `#{canonical_setting_name}`"))
-      end
-    end
-  end
+  # xcontext "when both the canonical setting and deprecated alias are set" do
+  #   before(:each) do
+  #     settings.set(deprecated_setting_name, "crusty_value")
+  #     settings.set(canonical_setting_name, "shiny_value")
+  #   end
+  #
+  #   context '#validate_value' do
+  #     it "raises helpful exception" do
+  #       expect { settings.get_setting(canonical_setting_name).validate_value }
+  #         .to raise_exception(java.lang.IllegalStateException, a_string_including("Both `#{canonical_setting_name}` and its deprecated alias `#{deprecated_setting_name}` have been set. Please only set `#{canonical_setting_name}`"))
+  #     end
+  #   end
+  # end
 
   context 'Settings#get on deprecated alias' do
     it 'produces a WARN-level message to the logger' do
+      puts "DNADBG>> inside the test"
       settings.get(deprecated_setting_name)
+      puts "DNADBG>> inside the test - after exercise"
       expect(events[0].message.formatted_message).to include("setting `#{canonical_setting_name}` has been queried by its deprecated alias `#{deprecated_setting_name}`")
     end
   end


### PR DESCRIPTION
Reworked log capture in setting_with_deprecated_alias_spec to use Logger's addAppender and a spy appender implementation.
This leverages the idea to don't reconfigure the Log4J with a custom build configuration, but simply adding an appender that could spy the appended lines to a logger, like described in https://github.com/andsel/log4j2_log_spy?tab=readme-ov-file#idea-2---add-a-customer-appender-to-the-logger-to-collect-the-messages.

The idea is use a list as a message accumulator, but the strange thing is that a message just added disappear and re-appear without an apparent motivation.

```
org.logstash.RSpecTests > rspecTests[core tests] STANDARD_OUT
    Run options: exclude {:integration=>true, :redis=>true, :socket=>true, :performance=>true, :couchdb=>true, :elasticsearch=>true, :elasticsearch_secure=>true, :export_cypher=>true, :windows=>true}

    Randomized with seed 64075

    LogStash::Setting::SettingWithDeprecatedAlias
      Settings#get on deprecated alias
    DNADBG>> before - before calling log.info, events: ["12345"]
    DNADBG>> CustomAppender.append invoked log_event: Logger=org.logstash.settings.DeprecatedAlias Level=INFO Message=Test ping message
    DNADBG>> CustomAppender.append invoked list content: ["12345", "Test ping message"]
    DNADBG>> before - just after called log.info, events: ["12345"]
    DNADBG>> inside the test
    DNADBG>> CustomAppender.append invoked log_event: Logger=org.logstash.settings.DeprecatedAlias Level=WARN Message=The value of setting `canonical.setting` has been queried by its deprecated alias `legacy.setting`. Code should be updated to query `canonical.setting` instead
    DNADBG>> CustomAppender.append invoked list content: ["12345", "Test ping message", "The value of setting `canonical.setting` has been queried by its deprecated alias `legacy.setting`. Code should be updated to query `canonical.setting` instead"]
    DNADBG>> inside the test - after exercise
        produces a WARN-level message to the logger (FAILED - 1)

    Failures:

      1) LogStash::Setting::SettingWithDeprecatedAlias Settings#get on deprecated alias produces a WARN-level message to the logger
         Failure/Error: expect(events[0].message.formatted_message).to include("setting `#{canonical_setting_name}` has been queried by its deprecated alias `#{deprecated_setting_name}`")

         NoMethodError:
           undefined method `message' for nil:NilClass
         # ./logstash-core/spec/logstash/settings/setting_with_deprecated_alias_spec.rb:199:in `block in <main>'
         # ./spec/spec_helper.rb:84:in `block in <main>'
         # ./logstash-core/lib/logstash/util.rb:43:in `set_thread_name'
         # ./spec/spec_helper.rb:83:in `block in <main>'
         # ./spec/spec_helper.rb:76:in `block in <main>'
         # ./vendor/bundle/jruby/3.1.0/gems/logstash-devutils-2.6.2-java/lib/logstash/devutils/rspec/spec_helper.rb:47:in `block in <main>'
         # ./lib/bootstrap/rspec.rb:36:in `<main>'

    Finished in 0.01929 seconds (files took 0.03019 seconds to load)
    1 example, 1 failure
```